### PR TITLE
Fix WSL install prompt on systems without WSL

### DIFF
--- a/visualstudio-project/ClaudeUsage/ClaudeUsage/Services/CredentialService.cs
+++ b/visualstudio-project/ClaudeUsage/ClaudeUsage/Services/CredentialService.cs
@@ -25,12 +25,15 @@ public class CredentialService
         );
     }
 
-    private static async Task<bool> IsWslAvailableAsync()
+    private static bool IsWslInstalled()
     {
+        // See UsageApiService.IsWslInstalled — checks the WSL distro registry
+        // key without invoking wsl.exe or touching \\wsl$ paths.
         try
         {
-            var task = Task.Run(() => Directory.Exists(@"\\wsl$") || Directory.Exists(@"\\wsl.localhost"));
-            return await task.WaitAsync(TimeSpan.FromSeconds(5));
+            using var lxss = Microsoft.Win32.Registry.CurrentUser
+                .OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss");
+            return lxss?.GetSubKeyNames().Length > 0;
         }
         catch
         {
@@ -66,43 +69,48 @@ public class CredentialService
             }
         }
 
-        // 2. Check WSL paths (try both \\wsl$ and \\wsl.localhost)
-        await Task.Run(() =>
+        // 2. Check WSL paths (only if WSL is actually installed — accessing
+        //    \\wsl$\ or \\wsl.localhost\ UNC paths on a system without WSL
+        //    triggers the Microsoft Store install prompt). See issue #4.
+        if (IsWslInstalled())
         {
-            string[] wslDistros = ["Debian", "Ubuntu", "Ubuntu-22.04", "Ubuntu-20.04", "kali-linux"];
-            string[] wslRoots = [@"\\wsl.localhost", @"\\wsl$"];
-
-            foreach (var wslRoot in wslRoots)
-            foreach (var distro in wslDistros)
+            await Task.Run(() =>
             {
-                try
-                {
-                    var wslHomePath = $@"{wslRoot}\{distro}\home";
-                    if (!Directory.Exists(wslHomePath)) continue;
+                string[] wslDistros = ["Debian", "Ubuntu", "Ubuntu-22.04", "Ubuntu-20.04", "kali-linux"];
+                string[] wslRoots = [@"\\wsl.localhost", @"\\wsl$"];
 
-                    foreach (var userDir in Directory.GetDirectories(wslHomePath))
+                foreach (var wslRoot in wslRoots)
+                foreach (var distro in wslDistros)
+                {
+                    try
                     {
-                        var credPath = Path.Combine(userDir, ".claude", ".credentials.json");
-                        if (File.Exists(credPath))
+                        var wslHomePath = $@"{wslRoot}\{distro}\home";
+                        if (!Directory.Exists(wslHomePath)) continue;
+
+                        foreach (var userDir in Directory.GetDirectories(wslHomePath))
                         {
-                            try
+                            var credPath = Path.Combine(userDir, ".claude", ".credentials.json");
+                            if (File.Exists(credPath))
                             {
-                                candidates.Add((credPath, File.GetLastWriteTimeUtc(credPath)));
+                                try
+                                {
+                                    candidates.Add((credPath, File.GetLastWriteTimeUtc(credPath)));
+                                }
+                                catch
+                                {
+                                    candidates.Add((credPath, DateTime.MinValue));
+                                }
+                                System.Diagnostics.Debug.WriteLine($"Found WSL credentials at: {credPath}");
                             }
-                            catch
-                            {
-                                candidates.Add((credPath, DateTime.MinValue));
-                            }
-                            System.Diagnostics.Debug.WriteLine($"Found WSL credentials at: {credPath}");
                         }
                     }
+                    catch (Exception ex)
+                    {
+                        System.Diagnostics.Debug.WriteLine($"WSL path error ({wslRoot}\\{distro}): {ex.Message}");
+                    }
                 }
-                catch (Exception ex)
-                {
-                    System.Diagnostics.Debug.WriteLine($"WSL path error ({wslRoot}\\{distro}): {ex.Message}");
-                }
-            }
-        }).WaitAsync(TimeSpan.FromSeconds(10));
+            }).WaitAsync(TimeSpan.FromSeconds(10));
+        }
 
         if (candidates.Count == 0)
         {

--- a/visualstudio-project/ClaudeUsage/ClaudeUsage/Services/UsageApiService.cs
+++ b/visualstudio-project/ClaudeUsage/ClaudeUsage/Services/UsageApiService.cs
@@ -13,29 +13,54 @@ public class UsageApiService
 
     private static string? _cachedClaudeCodeVersion;
 
-    private static string GetClaudeCodeVersion()
-    {
-        if (_cachedClaudeCodeVersion != null)
-            return _cachedClaudeCodeVersion;
-
-        try
-        {
-            // Try native Windows first, then WSL
-            var version = TryGetVersionFromProcess("claude", "--version")
-                       ?? TryGetVersionFromProcess("wsl", "claude --version");
-
-            _cachedClaudeCodeVersion = version ?? "2.1.0";
-            System.Diagnostics.Debug.WriteLine($"Claude Code version detected: {_cachedClaudeCodeVersion}");
-        }
-        catch
-        {
-            _cachedClaudeCodeVersion = "2.1.0";
-            System.Diagnostics.Debug.WriteLine("Claude Code version detection failed, using fallback 2.1.0");
-        }
-
+private static string GetClaudeCodeVersion()
+{
+    if (_cachedClaudeCodeVersion != null)
         return _cachedClaudeCodeVersion;
+
+    try
+    {
+        // Try native Windows first via cmd.exe so PATHEXT resolves claude.cmd
+        // (npm installs Claude Code as claude.cmd, which Process.Start with
+        // UseShellExecute=false cannot find directly — see issue #4).
+        var version = TryGetVersionFromProcess("cmd.exe", "/c claude --version");
+
+        // Fall back to WSL only if WSL is actually installed. Invoking wsl.exe
+        // on a system without WSL triggers the Microsoft Store install prompt
+        // rather than failing — see issue #4.
+        if (version == null && IsWslInstalled())
+        {
+            version = TryGetVersionFromProcess("wsl", "claude --version");
+        }
+
+        _cachedClaudeCodeVersion = version ?? "2.1.0";
+        System.Diagnostics.Debug.WriteLine($"Claude Code version detected: {_cachedClaudeCodeVersion}");
+    }
+    catch
+    {
+        _cachedClaudeCodeVersion = "2.1.0";
+        System.Diagnostics.Debug.WriteLine("Claude Code version detection failed, using fallback 2.1.0");
     }
 
+    return _cachedClaudeCodeVersion;
+}
+
+private static bool IsWslInstalled()
+{
+    // Enumerate registered WSL distros without invoking wsl.exe. The Lxss
+    // registry key contains a subkey (GUID-named) per installed distro;
+    // absent or empty means no distros are installed.
+    try
+    {
+        using var lxss = Microsoft.Win32.Registry.CurrentUser
+            .OpenSubKey(@"SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss");
+        return lxss?.GetSubKeyNames().Length > 0;
+    }
+    catch
+    {
+        return false;
+    }
+}
     private static string? TryGetVersionFromProcess(string fileName, string arguments)
     {
         try


### PR DESCRIPTION
## Summary

Fixes #4 — the app prompts to install WSL at every startup on systems where Claude Code is installed natively via npm and WSL is not installed.

## Root cause — two compounding code paths

**1. `UsageApiService.GetClaudeCodeVersion()`** spawns `claude --version` to populate the `User-Agent`. npm installs Claude Code as `%APPDATA%\npm\claude.cmd`, a `.cmd` shim. `Process.Start("claude", …, UseShellExecute = false)` uses `CreateProcess` under the hood, which doesn't honor `PATHEXT`, so the shim isn't found. Execution falls through to `Process.Start("wsl", "claude --version")`, which triggers the install prompt.

**2. `CredentialService.FindCredentialsPathAsync()`** iterates over `\\wsl$\<distro>\home` and `\\wsl.localhost\<distro>\home` via `Directory.Exists()`. On Windows 11 the LXSS redirector intercepts these UNC checks even when no WSL distros are installed, producing the same prompt. The codebase also contained a dead `IsWslAvailableAsync()` method that was never wired up.

## Fix

- Native version lookup now goes through `cmd.exe /c claude --version` so `PATHEXT` resolves `claude.cmd`
- New `IsWslInstalled()` helper enumerates `HKCU\SOFTWARE\Microsoft\Windows\CurrentVersion\Lxss` subkeys (one per registered distro) without invoking `wsl.exe` or touching `\\wsl$` paths
- Both the WSL version-fallback and the credential UNC scan are gated behind `IsWslInstalled()`
- Dead `IsWslAvailableAsync()` removed

## Test plan

- [x] On a Windows 11 host without WSL installed and with Claude Code installed via npm, run the new build — no Microsoft Store prompt appears
- [ ] Tray icon populates real percentages (not "!" error state) when credentials and Anthropic API are reachable
- [ ] On a host with WSL installed (with at least one distro registered under `HKCU\…\Lxss`), credential discovery and version detection still fall back to WSL as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)
