### PR TITLE
Fix usage retrieval: version parser, nullable extras, retry policy

### DIFF
--- a/visualstudio-project/ClaudeUsage/ClaudeUsage/Models/UsageData.cs
+++ b/visualstudio-project/ClaudeUsage/ClaudeUsage/Models/UsageData.cs
@@ -69,15 +69,19 @@ public class ExtraUsageData
     [JsonPropertyName("is_enabled")]
     public bool IsEnabled { get; set; }
 
+    // monthly_limit and used_credits arrive as null when extra usage is not enabled.
     [JsonPropertyName("monthly_limit")]
-    public double MonthlyLimit { get; set; }
+    public double? MonthlyLimit { get; set; }
 
     [JsonPropertyName("used_credits")]
-    public double UsedCredits { get; set; }
+    public double? UsedCredits { get; set; }
 
-    public double LimitDollars => MonthlyLimit / 100.0;
-    public double UsedDollars => UsedCredits / 100.0;
-    public int UtilizationPercent => MonthlyLimit > 0 ? (int)(UsedCredits / MonthlyLimit * 100) : 0;
+    public double LimitDollars => (MonthlyLimit ?? 0) / 100.0;
+    public double UsedDollars => (UsedCredits ?? 0) / 100.0;
+    public int UtilizationPercent =>
+        MonthlyLimit is > 0 && UsedCredits is not null
+            ? (int)(UsedCredits.Value / MonthlyLimit.Value * 100)
+            : 0;
 }
 
 public class CredentialsFile

--- a/visualstudio-project/ClaudeUsage/ClaudeUsage/Services/UsageApiService.cs
+++ b/visualstudio-project/ClaudeUsage/ClaudeUsage/Services/UsageApiService.cs
@@ -24,13 +24,13 @@ public class UsageApiService
             var version = TryGetVersionFromProcess("claude", "--version")
                        ?? TryGetVersionFromProcess("wsl", "claude --version");
 
-            _cachedClaudeCodeVersion = version ?? "2.1.0";
+            _cachedClaudeCodeVersion = version ?? "2.1.100";
             System.Diagnostics.Debug.WriteLine($"Claude Code version detected: {_cachedClaudeCodeVersion}");
         }
         catch
         {
-            _cachedClaudeCodeVersion = "2.1.0";
-            System.Diagnostics.Debug.WriteLine("Claude Code version detection failed, using fallback 2.1.0");
+            _cachedClaudeCodeVersion = "2.1.100";
+            System.Diagnostics.Debug.WriteLine("Claude Code version detection failed, using fallback 2.1.100");
         }
 
         return _cachedClaudeCodeVersion;
@@ -52,24 +52,26 @@ public class UsageApiService
             };
 
             process.Start();
-            var output = process.StandardOutput.ReadToEnd().Trim();
+            var stdout = process.StandardOutput.ReadToEnd().Trim();
+            var stderr = process.StandardError.ReadToEnd().Trim();
             process.WaitForExit(5000);
 
-            if (!string.IsNullOrWhiteSpace(output))
+            // Extract first dotted-version substring. Handles "2.1.143",
+            // "claude-code 1.2.3", and "2.1.143 (Claude Code)" — the last
+            // shape broke the previous split-and-take-last-token approach.
+            var match = System.Text.RegularExpressions.Regex.Match(stdout, @"\d+\.\d+(?:\.\d+)?");
+            if (match.Success)
             {
-                // Output may be "1.2.3" or "claude-code 1.2.3" — take last token
-                var parts = output.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-                var versionString = parts[^1];
-
-                if (System.Text.RegularExpressions.Regex.IsMatch(versionString, @"^\d+\.\d+"))
-                {
-                    return versionString;
-                }
+                return match.Value;
             }
+
+            System.Diagnostics.Debug.WriteLine(
+                $"Version probe [{fileName} {arguments}] no match: exit={process.ExitCode}, stdout='{stdout}', stderr='{stderr}'");
         }
-        catch
+        catch (Exception ex)
         {
-            // Process not found or failed
+            System.Diagnostics.Debug.WriteLine(
+                $"Version probe [{fileName} {arguments}] threw: {ex.Message}");
         }
 
         return null;
@@ -122,11 +124,11 @@ public class UsageApiService
 
                 return null;
             }
-            catch (Exception ex)
+            catch (Exception ex) when (ex is HttpRequestException or TaskCanceledException)
             {
+                // Transient transport/timeout failures — retry with backoff.
                 System.Diagnostics.Debug.WriteLine(
-                    $"Exception in GetUsageAsync (attempt {attempt + 1}/{MaxRetries + 1}): {ex.Message}");
-                System.Diagnostics.Debug.WriteLine($"Stack trace: {ex.StackTrace}");
+                    $"Transient exception in GetUsageAsync (attempt {attempt + 1}/{MaxRetries + 1}): {ex.Message}");
 
                 if (attempt < MaxRetries)
                 {
@@ -135,6 +137,16 @@ public class UsageApiService
                     continue;
                 }
 
+                return null;
+            }
+            catch (Exception ex)
+            {
+                // Non-transient (e.g. JsonException): the request succeeded but
+                // we can't use the response. Retrying won't fix it and burns
+                // rate-limit budget — fail fast.
+                System.Diagnostics.Debug.WriteLine(
+                    $"Non-retryable exception in GetUsageAsync: {ex.Message}");
+                System.Diagnostics.Debug.WriteLine($"Stack trace: {ex.StackTrace}");
                 return null;
             }
         }


### PR DESCRIPTION
## Summary

Three independent client-side bugs that prevented the usage API response from rendering on a fresh install. All affect every user on the current API, not just specific environments.

- **Version parser** ([UsageApiService.cs](visualstudio-project/ClaudeUsage/ClaudeUsage/Services/UsageApiService.cs)) — `claude --version` now emits `"2.1.143 (Claude Code)"`. The old split-and-take-last-token parser picked `"Code)"` and rejected it, falling back to the hardcoded `2.1.0` UA, which the API throttles aggressively. Replaced with a regex that extracts the first dotted-version substring (also handles the older `"claude-code 1.2.3"` shape). Bumped the hardcoded fallback to `2.1.100` for defense-in-depth, and surfaced `stdout`/`stderr` on detection failure instead of swallowing silently.

- **JSON model** ([UsageData.cs](visualstudio-project/ClaudeUsage/ClaudeUsage/Models/UsageData.cs)) — `extra_usage.monthly_limit` and `used_credits` arrive as `null` from the API when extras are disabled, but the model declared them as non-nullable `double`, throwing `JsonException` on every otherwise-successful response. Made both `double?` and updated the computed properties to coalesce.

- **Retry policy** ([UsageApiService.cs](visualstudio-project/ClaudeUsage/ClaudeUsage/Services/UsageApiService.cs)) — the catch block retried on any exception, including `JsonException`. A parse failure means the request *succeeded* — retrying compounds a client-side bug into a self-inflicted 429 burst on the usage endpoint. Narrowed retryable exceptions to `HttpRequestException` and `TaskCanceledException`.

## Test plan

- [x] Build cleanly with `dotnet build`
- [x] Run from a debugger, click tray icon, observe `Claude Code version detected: <real version>` log
- [x] Confirm `API Response: {...}` is followed by populated gauges (no `JsonException`)
- [x] Verify the popup shows session + weekly gauges and the Sonnet/Overage cards render (with Overage showing disabled state when `extra_usage.is_enabled: false`)

Independent of #5 (WSL install prompt fix) — these are unrelated to the WSL path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)