### PR TITLE
Bugfix: Off-Screen on First Tray Click

### DIFF
--- a/visualstudio-project/ClaudeUsage/ClaudeUsage/App.xaml.cs
+++ b/visualstudio-project/ClaudeUsage/ClaudeUsage/App.xaml.cs
@@ -55,6 +55,18 @@ public partial class App : System.Windows.Application
 
         // Create the main window (hidden initially)
         _mainWindow = new MainWindow();
+
+        // Realize the HWND and run an initial layout pass now, while hidden.
+        // Without this, the first tray click positions the window before it has
+        // been created/measured, so Left/Top don't fully apply and ActualHeight
+        // is still 0 — the popup appears partway off screen. ShowActivated=false
+        // keeps this from stealing focus or firing Deactivated.
+        _mainWindow.ShowActivated = false;
+        _mainWindow.Opacity = 0;
+        _mainWindow.Show();
+        _mainWindow.Hide();
+        _mainWindow.ShowActivated = true;
+
         _mainWindow.Deactivated += (s, args) =>
         {
             _lastDeactivated = DateTime.Now;


### PR DESCRIPTION
<img width="448" height="417" alt="Screenshot 2026-06-18 043912" src="https://github.com/user-attachments/assets/a5cacea7-fe4d-46e4-b181-1492204da6c4" />


**Issue**
The first time you click the tray icon after launching the app, the usage popup appears partly off the edge of the screen. Every subsequent click positions it correctly.

**Cause**
The popup window is created at startup but never shown, so it has no Win32 handle and has never been laid out. On the first click, ShowWithAnimation sets Left/Top and reads ActualHeight as part of the very first Show() — before the window is realized, WPF doesn't reliably apply Left/Top set before the HWND exists, so Windows falls back to a default position. After the first show the HWND persists (the window is hidden, not closed), which is why later clicks work.

**Fix**
Realize the window's handle and run one layout pass at startup, while it's hidden — ShowActivated = false and Opacity = 0 so it never flashes, steals focus, or fires the Deactivated handler. By the first real click the window is already created and measured, so positioning is correct and identical to every later click.

**Testing**
Manual: launch, click the tray icon, confirm the popup anchors to the bottom-right corner with no off-screen overflow.