### PR TITLE
Fix StackOverflow crash from re-entrant theme Changed handler

### DIFF
--- a/visualstudio-project/ClaudeUsage/ClaudeUsage/App.xaml.cs
+++ b/visualstudio-project/ClaudeUsage/ClaudeUsage/App.xaml.cs
@@ -364,10 +364,19 @@ public partial class App : System.Windows.Application
 
     private void OnThemeChanged(Wpf.Ui.Appearance.ApplicationTheme currentTheme, System.Windows.Media.Color systemAccent)
     {
-        // Apply the new theme to app-level resources (context menu, etc.)
+        // Rebuild app-level resources (context menu, etc.) for the new theme.
+        //
+        // Do NOT call ApplicationThemeManager.Apply here. By the time this handler
+        // runs the theme has ALREADY been applied — that is what raised Changed.
+        // In WPF-UI 3.0.5, Apply() unconditionally re-raises Changed (its
+        // ResourceDictionaryManager.UpdateDictionary replaces the theme dictionary
+        // and returns true even when the theme is unchanged), so calling Apply from
+        // inside the Changed handler recurses without a base case:
+        //   Changed -> OnThemeChanged -> Apply -> Changed -> ... -> StackOverflow.
+        // StackOverflowException is uncatchable, so the try/catch below does not
+        // save us — the process dies (0xC00000FD).
         try
         {
-            ApplicationThemeManager.Apply(currentTheme);
             CreateContextMenu();
         }
         catch (Exception ex)


### PR DESCRIPTION
## Summary

The app terminates with an uncatchable `StackOverflowException` (Windows
exception `0xC00000FD`, faulting module `coreclr.dll`) whenever the OS
broadcasts a theme/settings change. It reproduces deterministically — same
fault offset on every crash.

## Root cause

`App.OnThemeChanged` is subscribed to `ApplicationThemeManager.Changed`, and
from inside that handler it calls `ApplicationThemeManager.Apply(currentTheme)`
(`App.xaml.cs`):

```csharp
private void OnThemeChanged(ApplicationTheme currentTheme, Color systemAccent)
{
    try
    {
        ApplicationThemeManager.Apply(currentTheme);  // re-raises Changed
        CreateContextMenu();
    }
    ...
}
```

In **WPF-UI 3.0.5** (the pinned version), `Apply()` re-raises `Changed` at the
end, and it does so unconditionally for our call:

- `ApplicationThemeManager.Apply()` ends with
  `Changed?.Invoke(applicationTheme, ...)` — gated only on `isUpdated`.
- `isUpdated` comes from `ResourceDictionaryManager.UpdateDictionary()`, which
  finds the theme dictionary, replaces it with `new() { Source = newResourceUri }`,
  and **returns `true` with no old-vs-new URI comparison**.

So re-applying the *already-current* theme still reports "updated" and re-fires
`Changed`, with no base case:

```
Changed → OnThemeChanged → Apply → Changed → OnThemeChanged → Apply → … → StackOverflow
```

The kickoff is any OS theme/settings broadcast: `SystemThemeWatcher.Watch(this)`
(`MainWindow.xaml.cs`) turns a `WM_SETTINGCHANGE`/`ImmersiveColorSet` message
into one `Apply()` call, and the handler above turns that single event into
unbounded recursion. Because `StackOverflowException` is uncatchable in .NET,
the surrounding `try/catch` never helps and the process dies instantly with no
dialog.

## Fix

Remove the `Apply()` call from inside the `Changed` handler. By the time
`Changed` fires the theme is already applied (that is what raised the event), so
the call was redundant as well as fatal. `CreateContextMenu()` and the tray-icon
refresh remain and correctly pick up the already-applied theme.

## Testing

- Built the patched single-file exe (`dotnet publish -c Release -r win-x64
  -p:PublishSingleFile=true`) on .NET SDK 8.0.423.
- Before: toggling Windows dark/light (which broadcasts `WM_SETTINGCHANGE`)
  crashes the process every time — matching the `Application Error` /
  `0xC00000FD` events in Event Viewer.
- After: the process survives repeated dark/light toggles with no crash and no
  new crash events, and theming still updates correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
